### PR TITLE
Fix CA bundle path for Fedora 44

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt /usr/local/requirements.txt
 RUN pip3 install --no-dependencies -r /usr/local/requirements.txt
 
 # Allow a non-root user to install a custom root CA at run-time
-RUN chmod g+w /etc/pki/tls/certs/ca-bundle.crt
+RUN chmod g+w /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 COPY gitlab-prometheus-exporter.py /usr/local/bin/.
 COPY docker/ /docker/

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,7 +8,7 @@ main() {
   # installing CA certificate
   if [ -n "${CA_URL}" ] && [ ! -f "/tmp/.ca-imported" ]; then
     # Since update-ca-trust doesn't work as a non-root user, let's just append to the bundle directly
-    curl --silent --show-error --location "${CA_URL}" >> /etc/pki/tls/certs/ca-bundle.crt
+    curl --silent --show-error --location "${CA_URL}" >> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
     # Create a file so we know not to import it again if the container is restarted
     touch /tmp/.ca-imported
   fi


### PR DESCRIPTION
Fedora 44 no longer provides /etc/pki/tls/certs/ca-bundle.crt. The CA bundle is now at /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem.